### PR TITLE
Make file level tags optional

### DIFF
--- a/Lunr/Sniffs/Commenting/FileCommentSniff.php
+++ b/Lunr/Sniffs/Commenting/FileCommentSniff.php
@@ -97,12 +97,7 @@ class FileCommentSniff implements Sniff
         }
 
         // Required tags in correct order.
-        $required = array(
-                     '@package'    => true,
-                     '@author'     => true,
-                     '@copyright'  => true,
-                     '@license'    => true,
-                    );
+        $required = array();
 
         $foundTags = array();
         $previousName = NULL;


### PR DESCRIPTION
`@package` is entirely replaced with namespaces now
`@author` can be extracted from the git commit log
`@copyright` and `@license` will be replaced with SPDX headers