### PR TITLE
Add rules to detect unused and useless variables

### DIFF
--- a/Lunr/ruleset.xml
+++ b/Lunr/ruleset.xml
@@ -148,4 +148,11 @@
       <property name="searchAnnotations" value="true"/>
     </properties>
   </rule>
+
+  <rule ref="SlevomatCodingStandard.Variables.UnusedVariable">
+    <properties>
+      <property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true"/>
+    </properties>
+  </rule>
+  <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
 </ruleset>


### PR DESCRIPTION
Upstream doc, though not much: https://github.com/slevomat/coding-standard/blob/master/doc/variables.md#slevomatcodingstandardvariablesunusedvariable

Don't really consider either of those things "coding standard", but those are things that phpstan can't detect, while phpcs can.

"unused" should be clear. "useless" is for example and assignment before a use, like
```
$a = 'foo';
return $a;
```